### PR TITLE
Support Nested Routes

### DIFF
--- a/lib/Mojolicious/Plugin/OpenTelemetry.pm
+++ b/lib/Mojolicious/Plugin/OpenTelemetry.pm
@@ -14,7 +14,7 @@ sub register ( $, $app, $config, @ ) {
     $config->{tracer}{name} //= otel_config('SERVICE_NAME') // $app->moniker;
 
     $app->hook( around_action  => sub ( $next, $c, $action, $last, @ ) {
-        return unless $last;
+        return $next->() unless $last;
 
         my $tracer = otel_tracer_provider->tracer( %{ $config->{tracer} } );
 


### PR DESCRIPTION
The current `around_action` hook returns undef, which breaks whenever the hook is triggered [multiple times for the same request](https://docs.mojolicious.org/Mojolicious#around_action).

This PR changes the hook to return `$next->()` instead, fixing the plugin for applications that use nested routes.