### PR TITLE
Some small fixes from adding OpenTelemetry to a new CPAN Testers project

### DIFF
--- a/lib/Mojolicious/Plugin/OpenTelemetry.pm
+++ b/lib/Mojolicious/Plugin/OpenTelemetry.pm
@@ -5,6 +5,7 @@ our $VERSION = '0.006';
 
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
+use Scalar::Util qw( blessed );
 use Feature::Compat::Try;
 use OpenTelemetry -all;
 use OpenTelemetry::Constants -span;
@@ -74,7 +75,7 @@ sub register ( $, $app, $config, @ ) {
             if ($want) { @result    = $next->() }
             else       { $result[0] = $next->() }
 
-            my $promise = $result[0]->can('then')
+            my $promise = $result[0] && blessed $result[0] && $result[0]->can('then')
                 ? $result[0]
                 : Mojo::Promise->resolve(1);
 

--- a/lib/Mojolicious/Plugin/OpenTelemetry.pm
+++ b/lib/Mojolicious/Plugin/OpenTelemetry.pm
@@ -80,7 +80,7 @@ sub register ( $, $app, $config, @ ) {
                 : Mojo::Promise->resolve(1);
 
             $promise->then( sub {
-                my $code  = $tx->res->code;
+                my $code  = $tx->res->code || 0;
 
                 # The status of server spans must be left unset if the
                 # response is a 4XX error

--- a/t/basic.t
+++ b/t/basic.t
@@ -72,6 +72,11 @@ get '/error' => sub ( $c, @ ) {
     die 'oops';
 };
 
+get '/return' => sub ( $c, @ ) {
+    $c->render( text => 'OK' );
+    return;
+};
+
 # FIXME: The parent code is NOT instrumented
 under sub ($c, @) { 'A parent route' };
 get '/nested' => sub ( $c, @ ) {
@@ -345,6 +350,37 @@ describe 'Host / port parsing' => sub {
             },
         };
     };
+};
+
+subtest 'Controller methods need not return anything' => sub {
+    $tst->get_ok('/return')
+        ->status_is(200);
+
+    is $span->{otel}, {
+        attributes => {
+            'client.address'           => '127.0.0.1',
+            'client.port'              => T,
+            'http.request.method'      => 'GET',
+            'http.route'               => '/return',
+            'network.protocol.version' => '1.1',
+            'server.address'           => '127.0.0.1',
+            'server.port'              => T,
+            'url.path'                 => '/return',
+            'url.scheme'               => 'http',
+            'user_agent.original'      => 'Mojolicious (Perl)',
+        },
+        kind => SPAN_KIND_SERVER,
+        name => 'GET /return',
+        parent => D, # FIXME: cannot use an object check on 5.32?
+      # parent => object {
+      #     prop isa => 'OpenTelemetry::Context';
+      # },
+    };
+
+    span_calls [
+        set_attribute    => [ 'http.response.status_code', 200 ],
+        end              => [],
+    ];
 };
 
 done_testing;


### PR DESCRIPTION
Hi, I'm adding OpenTelemetry to a new CPAN Testers project so that I can have better insight into the problems, and I came across some things I thought I could improve.

First, I don't think Mojolicious route handlers are required to return anything, so I fixed the check for a Mojo::Promise object to make sure there's an object before trying to call a method. Before, I was getting an error about trying to call `can` on an unblessed scalar.

Then, while I left some stub route handlers that didn't do anything (just like `sub handle_get($c) {}`), I would get warnings about trying to compare `undef` using `>=`. The HTTP status code wasn't set, because the handler does nothing, but the warning could be confusing so I added a quick `|| 0` to silence it.

Thanks for creating this integration for Perl and Mojolicious! I've been pushing hard to get OpenTelemetry at $work, so I suspect I'll have future PRs for you :)