### PR TITLE
Guard around_action promise detection against non-thenable return

### DIFF
--- a/lib/Mojolicious/Plugin/OpenTelemetry.pm
+++ b/lib/Mojolicious/Plugin/OpenTelemetry.pm
@@ -74,9 +74,11 @@ sub register ( $, $app, $config, @ ) {
             if ($want) { @result    = $next->() }
             else       { $result[0] = $next->() }
 
-            my $promise = $result[0]->can('then')
-                ? $result[0]
-                : Mojo::Promise->resolve(1);
+            my $maybe = $result[0];
+            my $promise =
+                (defined $maybe && ref $maybe && $maybe->can('then'))
+                    ? $maybe
+                    : Mojo::Promise->resolve(1);
 
             $promise->then( sub {
                 my $code  = $tx->res->code;


### PR DESCRIPTION
## Summary

- Fix crash in around_action hook when controller returns undef or a non-promise value.
- Only treat the action result as a promise when it is a defined reference that implements `then`; otherwise, fall back to a resolved Mojo::Promise so spans are still closed.

## Details

Previously the plugin did:

```perl
my $promise = $result[0]->can('then')
    ? $result[0]
    : Mojo::Promise->resolve(1);
```

This assumes `$result[0]` is always defined and a reference. For actions that return nothing (common for synchronous actions that just render) or return a plain scalar, this can produce errors like "Can't call method 'can' on an undefined value".

The fix first stores the result in `$maybe` and only calls `can('then')` when it is defined, a reference, and responds to `then`:

```perl
my $maybe = $result[0];
my $promise =
    (defined $maybe && ref $maybe && $maybe->can('then'))
        ? $maybe
        : Mojo::Promise->resolve(1);
```

This preserves async behaviour for promise-returning actions and safely handles the common case where actions are purely synchronous.

## Testing

- Existing test suite exercises both synchronous and async routes, but the local environment here is missing `Test2::MojoX`, so tests couldn't be run locally. The change is narrowly scoped to the promise detection around the existing async test case.
